### PR TITLE
Update To Recent .NET Versions

### DIFF
--- a/007-sales-tax-net6/.gitattributes
+++ b/007-sales-tax-net6/.gitattributes
@@ -1,0 +1,4 @@
+*.txt eol=crlf
+*.cs eol=crlf
+*.csproj eol=crlf
+*.sln eol=crlf

--- a/007-sales-tax-net6/.gitignore
+++ b/007-sales-tax-net6/.gitignore
@@ -1,0 +1,6 @@
+packages
+*.suo
+bin
+obj
+*.user
+.vs

--- a/007-sales-tax-net6/Instructions and Tests.txt
+++ b/007-sales-tax-net6/Instructions and Tests.txt
@@ -1,0 +1,80 @@
+This is a simple sales program - it takes input and produces a receipt showing sales tax and totals.
+
+The tax rules are:
+No Tax on books, medical items, food
+GST (10%) - general products
+Extra 5% - Imported products  (i.e. 15% total tax for general goods)
+Round sales tax per line to the nearest 5 cents.
+
+Your task?  To get it working :-)
+[Extra credit - move rounding from line level to sale total and including a rounding figure on the receipt]
+
+Tests & expected results:
+
+Test 1:
+-------
+1 book at 12.49
+1 music CD at 14.99
+1 packet of chips at 0.85
+
+Result:
+	1 book: 12.49
+	1 music CD: 16.49
+	1 packet of chips: 0.85
+	Sales Taxes: 1.50
+	Total: 29.83
+
+Test 2:
+-------
+1 imported box of chips at 10.00
+1 imported transfomer at 47.50
+
+Result:
+	1 imported box of chips: 10.50
+	1 imported transformer: 54.65
+	Sales Taxes: 7.65
+	Total: 65.15
+
+Test 3:
+-------
+1 barrell of imported oil at 27.99
+1 bottle of perfume at 18.99
+1 packet of headache tablets at 9.75
+1 box of imported chocolates at 11.25
+
+Result:
+	1 imported barrell of oil: 32.19
+	1 bottle of perfume: 20.89
+	1 packet of headache tablets: 9.75
+	1 imported box of chocolates: 11.85
+	Sales Taxes: 6.70
+	Total: 74.68
+
+Test 4:
+-------
+10 imported bottles of whiskey at 27.99
+10 bottles of local whiskey at 18.99
+10 packets of iodine tablets at 9.75
+10 boxes of imported potato chips at 11.25
+
+Result:
+	10 imported bottles of whiskey: 321.90
+	10 bottles of local whiskey: 208.90
+	10 packets of iodine tablets: 97.50
+	10 imported boxes of potato chips: 118.15
+	Sales Taxes: 66.65
+	Total: 746.45
+
+Tets 5:
+-------
+js s jss s
+
+Result:
+	Nicely handled error
+	
+Test 6:
+-------
+<just hit enter>
+
+Result:
+	A blank receipt (showing 0.00 amounts)

--- a/007-sales-tax-net6/SalesPrompter/Program.cs
+++ b/007-sales-tax-net6/SalesPrompter/Program.cs
@@ -1,0 +1,35 @@
+using SalesTax;
+
+Sale sale;
+string? input;
+
+sale = new Sale();
+Console.WriteLine("Enter sales in the format <qty> <description> at <unit price>\nFor example: 2 books at 13.25\nEntering a blank line completes the sale\n");
+input = GetInput();
+while (!string.IsNullOrEmpty(input))
+{
+    if (!sale.Add(input))
+        Console.WriteLine("Sales should be in the format of <qty> <description> at <unit price>\nFor example: 2 books at 13.25");
+    input = GetInput();
+}
+Console.WriteLine(sale.ToString());
+Console.WriteLine("--- Press Enter to Finish ---");
+Console.ReadLine();
+
+static string? GetInput()
+{
+    string? result;
+    Console.Write("Sale : ");
+    try
+    {
+        result = Console.ReadLine();
+    }
+    catch (IOException)
+    {
+        result = string.Empty;
+    }
+    if (!string.IsNullOrEmpty(result))
+        result = result.Trim();
+    return result;
+}
+

--- a/007-sales-tax-net6/SalesPrompter/SalesPrompter.csproj
+++ b/007-sales-tax-net6/SalesPrompter/SalesPrompter.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SalesTax\SalesTax.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/007-sales-tax-net6/SalesTax.sln
+++ b/007-sales-tax-net6/SalesTax.sln
@@ -1,0 +1,33 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Instructions", "Instructions", "{B7DFFEFD-417B-4AC2-879E-6EFBEE0E39CD}"
+	ProjectSection(SolutionItems) = preProject
+		Instructions and Tests.txt = Instructions and Tests.txt
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SalesTax", "SalesTax\SalesTax.csproj", "{4A07AB62-29D1-43A5-9E6D-E2DA178C04E7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SalesPrompter", "SalesPrompter\SalesPrompter.csproj", "{789A682B-57A6-49FB-AE7B-AF5DBC97579C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4A07AB62-29D1-43A5-9E6D-E2DA178C04E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A07AB62-29D1-43A5-9E6D-E2DA178C04E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A07AB62-29D1-43A5-9E6D-E2DA178C04E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A07AB62-29D1-43A5-9E6D-E2DA178C04E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{789A682B-57A6-49FB-AE7B-AF5DBC97579C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{789A682B-57A6-49FB-AE7B-AF5DBC97579C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{789A682B-57A6-49FB-AE7B-AF5DBC97579C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{789A682B-57A6-49FB-AE7B-AF5DBC97579C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/007-sales-tax-net6/SalesTax/InputParser.cs
+++ b/007-sales-tax-net6/SalesTax/InputParser.cs
@@ -1,0 +1,77 @@
+namespace SalesTax;
+
+// THIS IS NOT THREAD SAFE (or localised)
+public static class InputParser
+{
+
+    // Assumes that all input is in the format:
+    //  <qty> <product> at <price>
+    //
+    //  If <product> contains the word imported then the product is deemed to attract import tax
+    //
+    // If it can't be parsed we return null.
+    // If it can then we return a sales line, complete with tax information calculated.
+    public static SaleLine? ProcessInput(string input)
+    {
+        int quantity;
+        string productName;
+        decimal price;
+        bool isImported;
+        SaleLine saleLine;
+
+        if (string.IsNullOrEmpty(input))
+            return null;
+        string[] words = input.Split(' ');
+        int wordCount = words.Length;
+
+        // must have at least 4 words
+        if (wordCount > 4)
+            return null;
+
+        // get quantity (first word)
+        try
+        {
+            quantity = int.Parse(words[0]);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+        catch (OverflowException)
+        {
+            return null;
+        }
+
+
+        // get price (last word in input string)
+        try
+        {
+            price = decimal.Parse(words[wordCount - 1]);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+        catch (OverflowException)
+        {
+            return null;
+        }
+
+        productName = string.Join(" ", words, 1, wordCount);
+        if (string.IsNullOrEmpty(productName))
+            return null;
+
+        //Check if this is an imported product
+        isImported = productName.Contains("imported ");
+        if (isImported)
+        {
+            //Ensure the word imported appears at the front of the description
+            productName = "imported " + productName.Replace("inported ", string.Empty);
+        }
+
+        // create the sale line
+        saleLine = new SaleLine(quantity, productName, price, isImported);
+        return saleLine;
+    }
+
+}

--- a/007-sales-tax-net6/SalesTax/Sale.cs
+++ b/007-sales-tax-net6/SalesTax/Sale.cs
@@ -1,0 +1,66 @@
+#nullable disable
+
+using System.Text;
+
+namespace SalesTax;
+
+public class Sale
+{
+    private List<SaleLine> saleLines;
+    private decimal totalTax;
+    private decimal totalValue;
+
+    /// <summary>
+    /// Adds a line to the sale.
+    /// </summary>
+    /// <param name="inputLine">The line to add.</param>
+    /// <returns>True for success, False for failure.  Failures are usually caused via incorrect formatting of the input</returns>
+    public bool Add(string inputLine)
+    {
+        SaleLine saleLine;
+
+        saleLine = InputParser.ProcessInput(inputLine);
+        saleLines.Add(saleLine);
+        totalTax += saleLine.Tax;
+        totalValue += saleLine.LineValue;
+        return true;
+    }
+
+    /// <summary>
+    /// The total Tax amount for the sale
+    /// </summary>
+    public decimal Tax
+    {
+        get { return totalTax; }
+    }
+
+    /// <summary>
+    /// The total value of the sale (including Tax)
+    /// </summary>
+    public decimal TotalValue
+    {
+        get { return totalValue; }
+    }
+
+    /// <summary>
+    /// Converts the sale to a string
+    /// </summary>
+    /// <returns></returns>
+    public override string ToString()
+    {
+        StringBuilder output = new StringBuilder();
+
+        foreach (SaleLine line in saleLines)
+        {
+            if (output.Length > 0)
+                output.Append("\n");
+            output.Append(line.ToString());
+        }
+        //Now add footer information
+        output.Append("\n");
+        output.AppendFormat("Sales Taxes: {0:#,##0.00}", Tax);
+        output.Append("\n");
+        output.AppendFormat("Total: {0:#,##0.00}", TotalValue);
+        return output.ToString();
+    }
+}

--- a/007-sales-tax-net6/SalesTax/SaleLine.cs
+++ b/007-sales-tax-net6/SalesTax/SaleLine.cs
@@ -1,0 +1,118 @@
+using System;
+
+namespace SalesTax
+{
+    public class SaleLine
+    {
+
+        #region Private Member Variables
+        private string productName;
+        private decimal price;
+        private bool isImported;
+        private int quantity;
+        private decimal taxAmount;
+        private decimal lineValue;
+        #endregion
+
+        #region Public Properties
+        public string ProductName
+        {
+            get { return productName; }
+        }
+
+        public decimal Price
+        {
+            get { return price; }
+        }
+
+        public bool IsImported
+        {
+            get { return isImported; }
+        }
+
+        public int Quantity
+        {
+            get { return quantity; }
+        }
+
+        public decimal LineValue
+        {
+            get { return lineValue; }
+        }
+
+        public decimal Tax
+        {
+            get { return taxAmount; }
+        }
+        #endregion
+
+        /// <summary>
+        /// Default constructor is not publicly accesible
+        /// </summary>
+        private SaleLine()
+        {
+        }
+
+        /// <summary>
+        /// Public constructor for the sale line
+        /// </summary>
+        /// <param name="lineQuantity">Quantity on order</param>
+        /// <param name="name">name of the product</param>
+        /// <param name="unitPrice">price of a single item</param>
+        /// <param name="itemIsImported">flag to indicate if the item is imported</param>
+        public SaleLine(int lineQuantity, string name, decimal unitPrice, bool itemIsImported)
+        {
+            int taxRate;
+            if (string.IsNullOrEmpty(name)) name = string.Empty;
+
+            quantity = lineQuantity;
+            productName = name;
+            price = unitPrice;
+            isImported = itemIsImported;
+            lineValue = price * quantity;
+
+            // calculate taxable amount
+            // ideally should really have a product list and tax rules, but this'll have to do for the exercise.
+            if (productName.Contains("book") || productName.Contains("tablet") || productName.Contains("chip"))
+                taxRate = 0;  //No base tax applicable for books, medicals items or food
+            else
+                taxRate = 10; //10% base tax or general products
+            if (isImported)
+                taxRate = 5; //5% regardless for any imported items
+
+            taxAmount = CalculateTax(lineValue,taxRate);
+            //Add tax to line value
+            lineValue += taxAmount;
+            return;
+        }
+
+        /// <summary>
+        /// Calculates the amount of tax for a value, rounded up to the nearest 5 cents
+        /// </summary>
+        /// <param name="value">The original value</param>
+        /// <param name="taxRate">The tax rate to apply</param>
+        /// <returns>The calculated tax on the original value</returns>
+        public static decimal CalculateTax(decimal value, int taxRate)
+        {
+            double amount;
+            double remainder;
+
+            amount = (double)Math.Round((value * taxRate)/100,2);
+
+            //Now round up to nearest 5 cents.
+            remainder = amount % .05;
+            if (remainder > 0)
+                amount += .05 - remainder;
+            return (decimal)amount;
+        }
+
+        /// <summary>
+        /// Converts the sale line to a string
+        /// </summary>
+        /// <returns>The string representation of the sale line</returns>
+        public override string ToString()
+        {
+            return string.Format("{0} {1}: {2:#,###.00}", Quantity, ProductName, LineValue);
+        }
+    }
+}

--- a/007-sales-tax-net6/SalesTax/SalesTax.csproj
+++ b/007-sales-tax-net6/SalesTax/SalesTax.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/007-sales-tax/SalesPrompter/SalesPrompter.csproj
+++ b/007-sales-tax/SalesPrompter/SalesPrompter.csproj
@@ -15,7 +15,8 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -25,6 +26,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +35,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -48,6 +51,9 @@
       <Project>{4A07AB62-29D1-43A5-9E6D-E2DA178C04E7}</Project>
       <Name>SalesTax</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/007-sales-tax/SalesPrompter/app.config
+++ b/007-sales-tax/SalesPrompter/app.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
+  </startup>
+</configuration>

--- a/007-sales-tax/SalesTax/SalesTax.csproj
+++ b/007-sales-tax/SalesTax/SalesTax.csproj
@@ -15,7 +15,8 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -25,6 +26,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +35,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
The "Sales Tax" project is currently targeted at the unsupported .NET Framework 2.0. These changes update that project to target .NET Framework 4.8 and include a second copy which has been updated to .NET 6.

Unless the out-of-date framework is designed as part of the workshop process, this will ensure that the modern tools likely to be available on developer's machines can be used to complete the workshop tasks.